### PR TITLE
Hsdo-905 paragraphs defaults bug

### DIFF
--- a/modules/stanford_paragraphs_defaults/stanford_paragraphs_defaults.features.inc
+++ b/modules/stanford_paragraphs_defaults/stanford_paragraphs_defaults.features.inc
@@ -340,8 +340,11 @@ function paragraphs_defaults_save(array $default, $module_name) {
   // Grab the paragraphs item_id properties.
   $item_ids = array();
   foreach ($default['paragraphs'] as $weight => $paragraph) {
-    list($item_id, ,) = entity_extract_ids('paragraphs_item', $paragraph['#entity']);
-    $item_ids[$item_id] = $weight;
+    // If the entity_type or bundle doesn't exist, skip that item.
+    if (isset($paragraph['#entity'])) {
+      list($item_id, ,) = entity_extract_ids('paragraphs_item', $paragraph['#entity']);
+      $item_ids[$item_id] = $weight;
+    }
   }
 
   // Write to the table to track the settings.
@@ -382,6 +385,13 @@ function _stanford_paragraphs_defaults_parse_default(&$data, $host_entity_type =
 
   // Find the entities starting points and create a new entity.
   if (isset($data['entity_type'])) {
+
+    // Make sure the bundle exists that its trying to make.
+    $entity_info = entity_get_info($data['entity_type']);
+    if (!$entity_info || !isset($entity_info['bundles'][$data['entity_bundle']])) {
+      return;
+    }
+
     $host_entity = _stanford_paragraphs_defaults_create_entity($data, $host_entity_type, $host_entity);
     $host_entity_type = $data['entity_type'];
   }
@@ -526,7 +536,7 @@ function _stanford_paragraphs_defaults_resave(&$entity_data) {
   }
 
   // Dive deep into the array before saving. This allows the nested entities
-  // to be saved first, which then sets the version ids correct for the paret
+  // to be saved first, which then sets the version ids correct for the parent
   // entities.
   foreach ($entity_data as &$item) {
     _stanford_paragraphs_defaults_resave($item);
@@ -546,20 +556,26 @@ function _stanford_paragraphs_defaults_resave(&$entity_data) {
  *   Feature name.
  */
 function _stanford_paragraphs_defaults_process_field_data(array &$values, $module_name) {
-  foreach ($values as &$value) {
+  foreach ($values as &$file_data) {
 
     // If field data is a file, copy and set the field data with the file.
-    if (is_array($value) && isset($value['uri'])) {
-      $file = _stanford_paragraphs_defaults_copy_file($value, $module_name);
+    if (is_array($file_data) && isset($file_data['uri'])) {
+      $file = _stanford_paragraphs_defaults_copy_file($file_data, $module_name);
       if ($file) {
-        $value = (array) $file;
+        foreach ($file_data as $key => $value) {
+          if ($key != 'uri') {
+            $file->{$key} = $value;
+          }
+        }
+
+        $file_data = (array) $file;
+
       }
       else {
-        $value = array();
+        $file_data = array();
       }
     }
   }
-
 }
 
 /**
@@ -574,13 +590,24 @@ function _stanford_paragraphs_defaults_process_field_data(array &$values, $modul
  *   File object if successful, false if failed.
  */
 function _stanford_paragraphs_defaults_copy_file(array $file_data, $module_name) {
-  $dir = 'public://paragraphs_defaults';
+  $dir = file_default_scheme() . '://paragraphs_defaults';
   file_prepare_directory($dir, FILE_CREATE_DIRECTORY | FILE_MODIFY_PERMISSIONS);
 
-  $dir = "public://paragraphs_defaults/$module_name";
+  $dir .= "/$module_name";
   file_prepare_directory($dir, FILE_CREATE_DIRECTORY | FILE_MODIFY_PERMISSIONS);
 
   $file_name = drupal_basename($file_data['uri']);
+
+  $fid = db_select('file_managed', 'f')
+    ->fields('f', array('fid'))
+    ->condition('uri', "$dir/$file_name")
+    ->execute()->fetchField();
+
+  // File already exists.
+  if ($fid) {
+    return file_load($fid);
+  }
+
   $file_path = drupal_get_path('module', $module_name) . '/' . $file_data['uri'];
   if (!file_exists($file_path)) {
     return FALSE;

--- a/modules/stanford_paragraphs_defaults/stanford_paragraphs_defaults.forms.inc
+++ b/modules/stanford_paragraphs_defaults/stanford_paragraphs_defaults.forms.inc
@@ -62,6 +62,9 @@ function stanford_paragraphs_defaults_overview() {
       }
     }
   }
+  if (!$output) {
+    $output['message']['#markup'] = t('No paragraph fields configured. Add a paragraph field to content to allow configuration of default settings.');
+  }
   return $output;
 }
 

--- a/modules/stanford_paragraphs_defaults/stanford_paragraphs_defaults.module
+++ b/modules/stanford_paragraphs_defaults/stanford_paragraphs_defaults.module
@@ -330,7 +330,12 @@ function stanford_paragraphs_defaults_create_default_existing($form, &$form_stat
   $label = trim($form_state['values']['title'] . ' ' . $increment);
   $machine_name = trim("{$machine_name}_$increment", '_');
   stanford_paragraphs_defaults_save_defaults($entity_type, $bundle, $field_name, $label, $machine_name, $paragraphs);
-  drupal_set_message(t('New default layout saved'));
+
+  $url = "admin/structure/paragraphs/stanford-defaults/edit/$entity_type-$bundle-$field_name-$machine_name";
+  drupal_set_message(t('New default layout %label saved. Edit new layout at !url', array(
+    '%label' => $label,
+    '!url' => l($url, $url),
+  )));
 
   $form_state['rebuild'] = TRUE;
 }

--- a/modules/stanford_paragraphs_defaults/stanford_paragraphs_defaults.module
+++ b/modules/stanford_paragraphs_defaults/stanford_paragraphs_defaults.module
@@ -331,6 +331,8 @@ function stanford_paragraphs_defaults_create_default_existing($form, &$form_stat
   $machine_name = trim("{$machine_name}_$increment", '_');
   stanford_paragraphs_defaults_save_defaults($entity_type, $bundle, $field_name, $label, $machine_name, $paragraphs);
   drupal_set_message(t('New default layout saved'));
+
+  $form_state['rebuild'] = TRUE;
 }
 
 /**

--- a/modules/stanford_paragraphs_defaults/stanford_paragraphs_defaults.module
+++ b/modules/stanford_paragraphs_defaults/stanford_paragraphs_defaults.module
@@ -28,6 +28,10 @@ function stanford_paragraphs_defaults_permission() {
       'title' => t('Administer Paragraph Types Defaults'),
       'description' => t('Create and modify default paragraph items.'),
     ),
+    'create stanford paragraph types defaults' => array(
+      'title' => t('Create Paragraph Types Defaults'),
+      'description' => t('Create new default layouts from existing content.'),
+    ),
   );
 }
 
@@ -218,8 +222,19 @@ function stanford_paragraphs_defaults_field_attach_form($entity_type, $entity, &
 
     // Skip this field if its already populated, if the default config was
     // already loaded, or if no defaults are configured.
-    if ($state['items_count'] ||
-      !$defaults ||
+    if ($state['items_count']) {
+      $form[$field_name][LANGUAGE_NONE]['add_more']['new_default'] = array(
+        '#type' => 'submit',
+        '#value' => t('Create new default from current content'),
+        '#name' => 'stanford_paragraphs_defaults_create_default_existing',
+        '#submit' => array('stanford_paragraphs_defaults_create_default_existing'),
+        '#access' => user_access('create stanford paragraph types defaults'),
+        '#entity_type' => $form_state['field'][$field_name][LANGUAGE_NONE]['instance']['entity_type'],
+        '#bundle' => $form_state['field'][$field_name][LANGUAGE_NONE]['instance']['bundle'],
+      );
+      continue;
+    }
+    elseif (!$defaults ||
       !isset($form[$field_name]) ||
       (strpos($uid, $field_name) !== FALSE)
     ) {
@@ -244,6 +259,29 @@ function stanford_paragraphs_defaults_field_attach_form($entity_type, $entity, &
       );
     }
   }
+}
+
+/**
+ * Create a new default layout from existing content.
+ *
+ * @param array $form
+ * @param array $form_state
+ */
+function stanford_paragraphs_defaults_create_default_existing($form, &$form_state) {
+  module_load_include('inc', 'stanford_paragraphs_defaults', 'stanford_paragraphs_defaults.forms');
+  $field_name = reset($form_state['triggering_element']['#parents']);
+  $entity_type = $form_state['triggering_element']['#entity_type'];
+  $bundle = $form_state['triggering_element']['#bundle'];
+  $paragraphs = $form_state['values'][$field_name];
+  foreach ($paragraphs[LANGUAGE_NONE] as $key => &$paragraph) {
+    if (!isset($paragraph['entity'])) {
+      unset($paragraphs[LANGUAGE_NONE][$key]);
+      continue;
+    }
+    $paragraph['entity'] = stanford_pragraphs_defaults_replicate_entity('paragraphs_item', $paragraph['entity']);
+  }
+  stanford_paragraphs_defaults_save_defaults($entity_type, $bundle, $field_name, $form_state['node']->title, 'testing', $paragraphs);
+  drupal_set_message(t('New default layout saved'));
 }
 
 /**
@@ -321,8 +359,6 @@ function _stanford_paragraphs_defaults_attach_default(array &$form, array &$form
   $items = array();
   foreach ($default['paragraphs'] as $paragraphs_item) {
     $cloned_item = stanford_pragraphs_defaults_replicate_entity('paragraphs_item', $paragraphs_item);
-    $cloned_item->item_id = NULL;
-    $cloned_item->revision_id = NULL;
     $items[]['entity'] = $cloned_item;
   }
 
@@ -448,9 +484,16 @@ function stanford_pragraphs_defaults_replicate_entity($entity_type, $entity) {
       $function = $module . '_replicate_entity_' . $entity_type;
       $function($clone);
     }
+    $entity_info = entity_get_info($entity_type);
 
     // Set the entity as new entity.
     $clone->is_new = TRUE;
+
+    // Clear the primary keys.
+    $id_key = $entity_info['entity keys']['id'];
+    $revision_key = $entity_info['entity keys']['revision'];
+    $clone->{$id_key} = NULL;
+    $clone->{$revision_key} = NULL;
 
     // Let other modules do special actions on each field.
     stanford_pragraphs_defaults_replicate_fields($clone, $entity_type);

--- a/modules/stanford_paragraphs_defaults/stanford_paragraphs_defaults.module
+++ b/modules/stanford_paragraphs_defaults/stanford_paragraphs_defaults.module
@@ -26,13 +26,30 @@ function stanford_paragraphs_defaults_permission() {
   return array(
     'administer stanford paragraph types defaults' => array(
       'title' => t('Administer Paragraph Types Defaults'),
-      'description' => t('Create and modify default paragraph items.'),
+      'description' => t('Create, modify, & delete default paragraph items.'),
     ),
     'create stanford paragraph types defaults' => array(
       'title' => t('Create Paragraph Types Defaults'),
-      'description' => t('Create new default layouts from existing content.'),
+      'description' => t('Create new default layouts.'),
     ),
   );
+}
+
+function stanford_paragraph_defaults_administer($operation) {
+  switch ($operation) {
+    case 'administer':
+      if (user_access('administer stanford paragraph types defaults')) {
+        return TRUE;
+      }
+      break;
+
+    case 'create':
+      if (user_access('administer stanford paragraph types defaults') || user_access('create stanford paragraph types defaults')) {
+        return TRUE;
+      }
+      break;
+  }
+  return FALSE;
 }
 
 /**
@@ -78,7 +95,8 @@ function stanford_paragraphs_defaults_menu() {
     'title' => 'Defaults',
     'page callback' => 'stanford_paragraphs_defaults_overview',
     'file' => 'stanford_paragraphs_defaults.forms.inc',
-    'access arguments' => array('administer stanford paragraph types defaults'),
+    'access callback' => 'stanford_paragraph_defaults_administer',
+    'access arguments' => array('create'),
     'type' => MENU_LOCAL_TASK | MENU_NORMAL_ITEM,
   );
   $items['admin/structure/paragraphs/stanford-defaults/overview'] = array(
@@ -90,7 +108,8 @@ function stanford_paragraphs_defaults_menu() {
     'page callback' => 'drupal_get_form',
     'page arguments' => array('stanford_paragraphs_defaults_add', 5, 6, 7),
     'file' => 'stanford_paragraphs_defaults.forms.inc',
-    'access arguments' => array('administer stanford paragraph types defaults'),
+    'access callback' => 'stanford_paragraph_defaults_administer',
+    'access arguments' => array('create'),
     'type' => MENU_NORMAL_ITEM,
   );
   $items['admin/structure/paragraphs/stanford-defaults/edit/%stanford_paragraphs_defaults'] = array(
@@ -98,7 +117,8 @@ function stanford_paragraphs_defaults_menu() {
     'page callback' => 'drupal_get_form',
     'page arguments' => array('stanford_paragraphs_defaults_edit', 5),
     'file' => 'stanford_paragraphs_defaults.forms.inc',
-    'access arguments' => array('administer stanford paragraph types defaults'),
+    'access callback' => 'stanford_paragraph_defaults_administer',
+    'access arguments' => array('administer'),
     'type' => MENU_NORMAL_ITEM,
   );
   $items['admin/structure/paragraphs/stanford-defaults/delete/%stanford_paragraphs_defaults'] = array(
@@ -106,7 +126,8 @@ function stanford_paragraphs_defaults_menu() {
     'page callback' => 'drupal_get_form',
     'page arguments' => array('stanford_paragraphs_defaults_delete', 5),
     'file' => 'stanford_paragraphs_defaults.forms.inc',
-    'access arguments' => array('administer stanford paragraph types defaults'),
+    'access callback' => 'stanford_paragraph_defaults_administer',
+    'access arguments' => array('administer'),
     'type' => MENU_NORMAL_ITEM,
   );
   return $items;
@@ -228,7 +249,7 @@ function stanford_paragraphs_defaults_field_attach_form($entity_type, $entity, &
         '#value' => t('Create new default from current content'),
         '#name' => 'stanford_paragraphs_defaults_create_default_existing',
         '#submit' => array('stanford_paragraphs_defaults_create_default_existing'),
-        '#access' => user_access('create stanford paragraph types defaults'),
+        '#access' => stanford_paragraph_defaults_administer('create'),
         '#entity_type' => $form_state['field'][$field_name][LANGUAGE_NONE]['instance']['entity_type'],
         '#bundle' => $form_state['field'][$field_name][LANGUAGE_NONE]['instance']['bundle'],
       );
@@ -273,6 +294,8 @@ function stanford_paragraphs_defaults_create_default_existing($form, &$form_stat
   $entity_type = $form_state['triggering_element']['#entity_type'];
   $bundle = $form_state['triggering_element']['#bundle'];
   $paragraphs = $form_state['values'][$field_name];
+
+  // Clone paragraph items.
   foreach ($paragraphs[LANGUAGE_NONE] as $key => &$paragraph) {
     if (!isset($paragraph['entity'])) {
       unset($paragraphs[LANGUAGE_NONE][$key]);
@@ -280,7 +303,33 @@ function stanford_paragraphs_defaults_create_default_existing($form, &$form_stat
     }
     $paragraph['entity'] = stanford_pragraphs_defaults_replicate_entity('paragraphs_item', $paragraph['entity']);
   }
-  stanford_paragraphs_defaults_save_defaults($entity_type, $bundle, $field_name, $form_state['node']->title, 'testing', $paragraphs);
+
+  // Create fake form_state to pass to
+  // _stanford_paragraphs_defaults_machine_name().
+  $state = array(
+    'entity_info' => array(
+      'entity_type' => $entity_type,
+      'bundle' => $bundle,
+      'field_name' => $field_name,
+    ),
+  );
+
+  $machine_name = preg_replace("/[^A-Za-z0-9_]/", '_', $form_state['values']['title']);
+  $machine_name = strtolower($machine_name);
+  $increment = '';
+
+  // Get unique machine name & label from the entity label.
+  while (_stanford_paragraphs_defaults_machine_name(trim("{$machine_name}_$increment", '_'), $form, $state)) {
+    if (!$increment) {
+      $increment = 0;
+    }
+    $increment++;
+  }
+
+  // Save new paragraph default setting.
+  $label = trim($form_state['values']['title'] . ' ' . $increment);
+  $machine_name = trim("{$machine_name}_$increment", '_');
+  stanford_paragraphs_defaults_save_defaults($entity_type, $bundle, $field_name, $label, $machine_name, $paragraphs);
   drupal_set_message(t('New default layout saved'));
 }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- If a file has already been copied from the feature, load that file instead. Since the default paragraph entities are deleted during cron instead of immediately (because of issues during feature rebuilding), the file could still exist.

# Needed By (Date)
- 6/22

# Urgency
- needed before we can tag and release the module.

# Steps to Test

1. Checkout branch & latest [stanford_story_page](https://github.com/SU-SWS/stanford_story_page)
2. revert feature stanford_story_page
3. delete some default configurations at `admin/structure/paragraphs/stanford-defaults`
4. revert stanford_story_page
5. validate no errors exist for file copying.
