### PR TITLE
Add autoplay handling to click action.

### DIFF
--- a/js/stanford_paragraph_types.p_hero.js
+++ b/js/stanford_paragraph_types.p_hero.js
@@ -31,7 +31,15 @@
               $dad.siblings('.group-overlay-text').hide();
               var iframe = $(video).find('iframe')[0];
 
-              iframe.src += "&autoplay=1";
+              // If autoplay is already there, change it to play.
+              if (iframe.src.search('autoplay=0') >= 1) {
+                iframe.src = iframe.src.replace('autoplay=0', 'autoplay=1');
+              }
+              // Otherwise add it.
+              else {
+                iframe.src += "&autoplay=1";
+              }
+
               $(iframe).attr('onload', 'this.contentWindow.focus()');
               $(video).show();
             }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fixes for autoplay when already on embed.
- When video_embed_field adds autoplay=0, appending autoplay=1 to the end of the url has no effect.
- In conjunction with https://github.com/SU-SWS/stanford_sites_jumpstart_plus/pull/27

# Needed By (Date)
- Soon

# Urgency
- Med-low, the workaround is to enable autoplay in the video_embed settings.

# Steps to Test

1. Clone the gup site to your local
2. Check out this branch
3. Load up the homepage
4. Click play on the youtube video
5. Have it autoplay

# Affected Projects or Products
- GUP
- ACSF

# Associated Issues and/or People
- ?
- https://github.com/SU-SWS/stanford_sites_jumpstart_plus/pull/27

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)